### PR TITLE
fix: encodingMethod when revoking a jwk key from didDocument 'hex' ->…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lacchain-identity",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Rest api for lacchain identity manager",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/services/did-lac/did.service.ts
+++ b/src/services/did-lac/did.service.ts
@@ -428,7 +428,7 @@ export abstract class DidService implements DidLacService {
       did: jwkAttribute.did,
       relation: jwkAttribute.relation,
       algorithm: 'jwk',
-      encodingMethod: 'hex',
+      encodingMethod: 'json',
       value: toUtf8Bytes(canonicalize(jwkAttribute.jwk)),
       revokeDeltaTime: jwkAttribute.revokeDeltaTime,
       compromised: jwkAttribute.compromised


### PR DESCRIPTION
… 'json'

## Pull request type

<!-- Please check the type of change your PR introduces: -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Link: N/A

## What is the new behavior?

- On revoking a jwk the encoding method is 'json' rather than 'hex'

## Other information

<!-- Please add any relevant information that assists the code review. -->

N/A

## Preview

N/A
